### PR TITLE
fixes in files 50F.yml and 60F.yml

### DIFF
--- a/buses/AEE2004.full/HS.IS/50F.yml
+++ b/buses/AEE2004.full/HS.IS/50F.yml
@@ -3,7 +3,9 @@ name: 'DSG_STATUS'
 length: 6
 type: 'can'
 periodicity: None
-senders: ['DSG']
+senders:
+  - 'DSG'
+receivers: [] #todo
 
 signals:
   STATUS_FRONT_LEFT:

--- a/buses/AEE2004.full/HS.IS/60F.yml
+++ b/buses/AEE2004.full/HS.IS/60F.yml
@@ -3,7 +3,9 @@ name: 'DSG_PRESSURE'
 length: 8
 type: 'can'
 periodicity: None
-senders: ['DSG']
+senders:
+  - 'DSG'
+receivers: [] #todo
 
 signals:
   PRESSURE_FRONT_LEFT:


### PR DESCRIPTION
There was some minor syntax differences in these files. I made them same as other CAN message files.
I'm trying to write dbmuxe -> dbc converter, so I need to be clear with syntax.
p.s. Is it good to write this converter in C++? Majority of this project is written in Python, but I'm not familiar with Python....